### PR TITLE
remove single quote escapes and merge language with text

### DIFF
--- a/zeal.py
+++ b/zeal.py
@@ -129,14 +129,10 @@ def open_zeal(lang, text, join_command):
             cmd = []
             cmd.append(zeal_exe)
             cmd.append(u"--query")
-            cmd.append(u"'")
             if join_command:
                 cmd.append(text)
             else:
-                cmd.append(lang)
-                cmd.append(u":")
-                cmd.append(text)
-            cmd.append(u"'")
+                cmd.append(lang + ":" + text)
             subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=False)
         except Exception as e:
             sublime.status_message("Zeal - (%s)" % (e))


### PR DESCRIPTION
Issue #4
I think sublime manages to escape everything himself well. This works well on Kubuntu 12.04, it does allow you to search for strings containing quotes(double and single) as well as spaces, so most probably ST does escape everything himself and that's why it's done using a list.
