### PR TITLE
If mapping is empty do not add language to zeal command

### DIFF
--- a/zeal.py
+++ b/zeal.py
@@ -162,7 +162,7 @@ def open_zeal(lang, text, join_command):
             cmd = []
             cmd.append(zeal_exe)
             cmd.append(u"--query")
-            if join_command:
+            if join_command or lang is None or lang == '':
                 cmd.append(text)
             else:
                 cmd.append(lang + ":" + text)


### PR DESCRIPTION
Hi

For some languages like ERB I want to disable completely the language mapping so they will search inside all of the languages by default. By default now if language is set it will prepend query with ":", this PR changes this behaviour so it will not add it.