### PR TITLE
Support for multiple scopes and handle sub Pythons

### DIFF
--- a/zeal.py
+++ b/zeal.py
@@ -28,7 +28,8 @@ def get_settings():
 
 
 def get_language(view):
-    scope = view.scope_name(view.sel()[0].begin()).strip()
+    scopes = view.scope_name(view.sel()[0].begin()).split()
+    scope = scopes[0].strip()
     getlang = scope.split('.')
     language = getlang[-1]
     # some langaue like CmakeEditor is cmakeeditor keyword
@@ -54,6 +55,8 @@ def get_language(view):
         language = 'actionscript'
     if 'source.cmake' in scope:
         language = 'cmake'
+    if 'source.python' in scope:
+        language = 'python'
     del getlang
     return language
 


### PR DESCRIPTION
The function `view.scope_name` can return a string of multiple scopes, when that happens, that last component of the last scope is used to guess the language. That can lead to Zeal not recognising the language.

```
# Method to fetch the scope before patch
print(view.scope_name(view.sel()[0].begin()))

# Example in Django. Before patch, yields model.
>>> source.python.django support.type.django.model

# Example in JSON. Before patch, yields json, from constant.language.json
>>> source.json meta.structure.dictionary.json meta.structure.dictionary.value.json constant.language.json 
```

The patch uses the first scope found. Further improvement could be made to always use the scopes starting with `source.` (and `text.`?). I also added a special rule for Python which helps with scopes like `source.python.django`.