### PR TITLE
Add Clojure/ClojureScript to default mappings.

### DIFF
--- a/Zeal.sublime-settings
+++ b/Zeal.sublime-settings
@@ -20,6 +20,8 @@
     "CSS": {"lang": "css", "zeal_lang": "css"},
     "PHP": {"lang": "php", "zeal_lang": "php"},
     "Python": {"lang": "python", "zeal_lang": "python"},
-    "Ruby": {"lang": "ruby", "zeal_lang":"ruby"}
+    "Ruby": {"lang": "ruby", "zeal_lang":"ruby"},
+    "Clojure": {"lang": "clojure", "zeal_lang": "clojure"},
+    "ClojureScript": {"lang": "clojurescript", "zeal_lang": "cljs"},
   }
 }


### PR DESCRIPTION
1. Zeal integration with Sublime Text is pretty great. I'm glad I found it.
2. It would be sweet if the package included more default mappings.
3. I added Clojure/ClojureScript to those mappings.